### PR TITLE
Feat: #8 - User 셋팅(회원가입,로그인,JWT,SpringSecurity 등)

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -3,4 +3,8 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-test'
+    implementation 'com.auth0:java-jwt:3.19.0'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }

--- a/api-server/src/main/java/com/daangndaangn/apiserver/configure/JwtConfigure.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/configure/JwtConfigure.java
@@ -1,0 +1,28 @@
+package com.daangndaangn.apiserver.configure;
+
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Jwt 라이브러리 관련 application.yml 설정
+ */
+@ToString
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtConfigure {
+
+    private String header;
+
+    private String issuer;
+
+    private String clientSecret;
+
+    private int expirySeconds;
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/configure/OAuthConfigure.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/configure/OAuthConfigure.java
@@ -1,0 +1,25 @@
+package com.daangndaangn.apiserver.configure;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kakao API(OAuth) 관련 application.yml 설정
+ */
+@ToString
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "oauth.kakao")
+public class OAuthConfigure {
+
+    private String headerKey;   // "Authorization"
+
+    private String headerValue; // "Bearer"
+
+    private String url; // "https://kapi.kakao.com/v2/user/me"
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/configure/ServiceConfigure.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/configure/ServiceConfigure.java
@@ -1,0 +1,34 @@
+package com.daangndaangn.apiserver.configure;
+
+import com.daangndaangn.apiserver.security.jwt.Jwt;
+import com.daangndaangn.apiserver.util.MessageUtils;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 프로젝트에서 사용하는 각종 Bean 모음
+ */
+@Configuration
+public class ServiceConfigure {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+
+    @Bean
+    public Jwt jwt(JwtConfigure jwtConfigure) {
+        return new Jwt(jwtConfigure.getIssuer(), jwtConfigure.getClientSecret(), jwtConfigure.getExpirySeconds());
+    }
+
+    @Bean
+    public MessageSourceAccessor messageSourceAccessor(MessageSource messageSource) {
+        MessageSourceAccessor messageSourceAccessor = new MessageSourceAccessor(messageSource);
+        MessageUtils.setMessageSourceAccessor(messageSourceAccessor);
+        return messageSourceAccessor;
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/configure/WebSecurityConfigure.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/configure/WebSecurityConfigure.java
@@ -1,0 +1,85 @@
+package com.daangndaangn.apiserver.configure;
+
+import com.daangndaangn.apiserver.entity.user.Role;
+import com.daangndaangn.apiserver.security.CustomAccessDeniedHandler;
+import com.daangndaangn.apiserver.security.CustomUnauthorizedHandler;
+import com.daangndaangn.apiserver.security.jwt.Jwt;
+import com.daangndaangn.apiserver.security.jwt.JwtAuthenticationProvider;
+import com.daangndaangn.apiserver.security.jwt.JwtAuthenticationTokenFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * SpringSecurity, 인증 인가 관련 설정 및 관련 Bean 모음
+ */
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class WebSecurityConfigure extends WebSecurityConfigurerAdapter {
+
+    private final Jwt jwt;
+    private final JwtConfigure jwtConfigure;
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final CustomUnauthorizedHandler unauthorizedHandler;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+    @Bean
+    public JwtAuthenticationTokenFilter jwtAuthenticationTokenFilter() {
+        return new JwtAuthenticationTokenFilter(jwt, jwtConfigure.getHeader());
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        // AuthenticationManager 는 AuthenticationProvider 목록을 지니고 있다.
+        // 이 목록에 JwtAuthenticationProvider 를 추가한다.
+        auth.authenticationProvider(jwtAuthenticationProvider);
+    }
+
+    @Override
+    public void configure(WebSecurity web) {
+        web.ignoring().antMatchers("/swagger-resources", "/webjars/**", "/static/**", "/templates/**", "/h2/**");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .csrf()
+                .disable()
+            .headers()
+                .disable()
+            .exceptionHandling()
+                .accessDeniedHandler(accessDeniedHandler)
+                .authenticationEntryPoint(unauthorizedHandler)
+                .and()
+            .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                    .antMatchers("/api/hcheck").permitAll() // 서버 상태 CHECK API는 모두 접근가능
+                    .antMatchers("/api/auth").permitAll()   // 로그인 API는 모두 접근가능
+                    .antMatchers("/api/users/join").permitAll()  // 회원 가입 API는 모두 접근가능
+                    .antMatchers("/api/**").hasRole(Role.USER.name())   // 그 외 API는 '회원 권한' 필요
+                .anyRequest().permitAll()
+                .and()
+            .formLogin()
+                .disable();
+        http
+            .addFilterBefore(jwtAuthenticationTokenFilter(), UsernamePasswordAuthenticationFilter.class);
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/ApiError.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/ApiError.java
@@ -1,0 +1,33 @@
+package com.daangndaangn.apiserver.controller;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * API 예외 스펙
+ * 모든 예외응답은 ApiError로 래핑되어 클라이언트에게 전달된다.
+ */
+@Getter
+public class ApiError {
+
+    private final String message;   // 오류 메시지
+
+    private final int status;   // HTTP 오류코드
+
+    public static ApiError of(Throwable throwable, HttpStatus status) {
+        return new ApiError(throwable, status);
+    }
+
+    public static ApiError of(String message, HttpStatus status) {
+        return new ApiError(message, status);
+    }
+
+    private ApiError(Throwable throwable, HttpStatus status) {
+        this(throwable.getMessage(), status);
+    }
+
+    private ApiError(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status.value();
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/ApiResult.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/ApiResult.java
@@ -1,0 +1,35 @@
+package com.daangndaangn.apiserver.controller;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+
+/**
+ * API 응답 스펙
+ * 모든 응답(정상 예외)은 ApiResult로 래핑되어 클라이언트에게 전달된다.
+ */
+@ToString
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResult<T> {
+
+    private final boolean success;
+
+    private final T response;
+
+    private final ApiError error;
+
+    public static <T> ApiResult<T> OK(T response) {
+        return new ApiResult<>(true, response, null);
+    }
+
+    public static ApiResult<?> ERROR(Throwable throwable, HttpStatus status) {
+        return new ApiResult<>(false, null, ApiError.of(throwable, status));
+    }
+
+    public static ApiResult<?> ERROR(String errorMessage, HttpStatus status) {
+        return new ApiResult<>(false, null, ApiError.of(errorMessage, status));
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/GeneralExceptionHandler.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/GeneralExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.daangndaangn.apiserver.controller;
+
+import com.daangndaangn.apiserver.error.NotFoundException;
+import com.daangndaangn.apiserver.error.ServiceRuntimeException;
+import com.daangndaangn.apiserver.error.UnauthorizedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+
+import static com.daangndaangn.apiserver.controller.ApiResult.ERROR;
+
+/**
+ * controller 계층에서 발생하는 모든 Exception 처리 전담
+ */
+@Slf4j
+@RestControllerAdvice
+public class GeneralExceptionHandler {
+
+    private ResponseEntity<ApiResult<?>> createResponse(Throwable throwable, HttpStatus status) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+        return new ResponseEntity<>(ERROR(throwable, status), headers, status);
+    }
+
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<?> handleHttpClientErrorException(HttpClientErrorException e) {
+        log.info("HttpClientError exception occurred: {}", e.getMessage(), e);
+        HttpStatus httpStatus = HttpStatus.valueOf(e.getRawStatusCode());
+        return createResponse(e, httpStatus);
+    }
+
+    @ExceptionHandler(RestClientException.class)
+    public ResponseEntity<?> handleRestClientException(RestClientException e) {
+        log.info("RestClient exception occurred: {}", e.getMessage(), e);
+        return createResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * 정의한 비즈니스 예외가 발생하는 경우
+     */
+    @ExceptionHandler(ServiceRuntimeException.class)
+    public ResponseEntity<?> handleServiceRuntimeException(ServiceRuntimeException e) {
+        if (e instanceof NotFoundException) {
+            return createResponse(e, HttpStatus.NOT_FOUND);
+        } else if (e instanceof UnauthorizedException) {
+            return createResponse(e, HttpStatus.UNAUTHORIZED);
+        }
+
+        log.warn("Unexpected service exception occurred: {}", e.getMessage(), e);
+        return createResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * 예측하지 못한 API Server Exception Handling
+     */
+    @ExceptionHandler({Exception.class, RuntimeException.class})
+    public ResponseEntity<?> handleException(Exception e) {
+        log.error("Unexpected exception occurred: {}", e.getMessage(), e);
+        return createResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/GeneralExceptionHandler.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/GeneralExceptionHandler.java
@@ -4,13 +4,17 @@ import com.daangndaangn.apiserver.error.NotFoundException;
 import com.daangndaangn.apiserver.error.ServiceRuntimeException;
 import com.daangndaangn.apiserver.error.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.multipart.MultipartException;
 
 import static com.daangndaangn.apiserver.controller.ApiResult.ERROR;
 
@@ -25,6 +29,16 @@ public class GeneralExceptionHandler {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Type", "application/json");
         return new ResponseEntity<>(ERROR(throwable, status), headers, status);
+    }
+
+    @ExceptionHandler({
+        IllegalStateException.class, IllegalArgumentException.class,
+        TypeMismatchException.class, HttpMessageNotReadableException.class,
+        MissingServletRequestParameterException.class, MultipartException.class,
+    })
+    public ResponseEntity<?> handleBadRequestException(Exception e) {
+        log.info("Bad request exception occurred: {}", e.getMessage(), e);
+        return createResponse(e, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(HttpClientErrorException.class)

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/HealthCheckRestController.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/HealthCheckRestController.java
@@ -1,0 +1,29 @@
+package com.daangndaangn.apiserver.controller;
+
+import com.daangndaangn.apiserver.security.jwt.JwtAuthentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 서버가 제대로 떠있는지 확인하는 용도의 샘플 Api Controller.
+ * /api/hcheck : 회원/비회원 모두 호출가능
+ * /api/hcheck/with-user : 회원만 호출가능
+ *
+ * 향후 삭제 예정
+ */
+@RequestMapping("/api/hcheck")
+@RestController
+public class HealthCheckRestController {
+
+    @GetMapping
+    public ApiResult<Long> getSystemTimeMillis() {
+        return ApiResult.OK(System.currentTimeMillis());
+    }
+
+    @GetMapping("/with-user")
+    public ApiResult<Long> getSystemTimeMillisWithUser(@AuthenticationPrincipal JwtAuthentication authentication) {
+        return ApiResult.OK(System.currentTimeMillis());
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/authentication/AuthApiController.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/authentication/AuthApiController.java
@@ -1,0 +1,44 @@
+package com.daangndaangn.apiserver.controller.authentication;
+
+import com.daangndaangn.apiserver.controller.ApiResult;
+import com.daangndaangn.apiserver.security.jwt.JwtAuthenticationToken;
+import com.daangndaangn.apiserver.security.oauth.OAuthDto;
+import com.daangndaangn.apiserver.security.oauth.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 로그인 API 처리 controller
+ */
+@RequestMapping("/api/auth")
+@RestController
+@RequiredArgsConstructor
+public class AuthApiController {
+
+    private final OAuthService oAuthService;
+    private final AuthenticationManager authenticationManager;
+
+    @PostMapping
+    public ApiResult<AuthenticationDto.Response> authentication(@RequestBody AuthenticationDto.Request authRequest) {
+
+        //accessToken to User
+        String accessToken = authRequest.getAccessToken();
+
+        //user에 대해 AuthenticationManager 동작
+        OAuthDto.Response oauthResponse = oAuthService.getUserInfo(OAuthDto.Request.from(accessToken));
+
+        JwtAuthenticationToken authToken = JwtAuthenticationToken.from(oauthResponse.getId());
+        Authentication authenticate = authenticationManager.authenticate(authToken);
+        SecurityContextHolder.getContext().setAuthentication(authenticate);
+
+        AuthenticationDto.Response response = (AuthenticationDto.Response)authenticate.getDetails();
+
+        return ApiResult.OK(response);
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/authentication/AuthenticationDto.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/authentication/AuthenticationDto.java
@@ -1,0 +1,46 @@
+package com.daangndaangn.apiserver.controller.authentication;
+
+import com.daangndaangn.apiserver.entity.user.User;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 인증(로그인) 요청/응답 Dto
+ */
+public class AuthenticationDto {
+
+    @Getter
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Request {
+        private String accessToken;
+    }
+
+    @Builder
+    @Getter
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Response {
+        //jwt
+        private String apiToken;
+
+        //userInfo
+        private String nickname;
+        private String email;
+        private String location;
+        private String profileUrl;
+        private Double manner;
+
+        public static Response of(String apiToken, User user) {
+            return Response.builder()
+                    .apiToken(apiToken)
+                    .nickname(user.getNickname())
+                    .email(user.getEmail().getAddress())
+                    .location(user.getLocation().getAddress())
+                    .profileUrl(user.getProfileUrl())
+                    .manner(user.getManner())
+                    .build();
+        }
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/user/UserApiController.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/user/UserApiController.java
@@ -1,0 +1,40 @@
+package com.daangndaangn.apiserver.controller.user;
+
+import com.daangndaangn.apiserver.controller.ApiResult;
+import com.daangndaangn.apiserver.entity.user.Email;
+import com.daangndaangn.apiserver.entity.user.Location;
+import com.daangndaangn.apiserver.security.oauth.OAuthDto;
+import com.daangndaangn.apiserver.security.oauth.OAuthService;
+import com.daangndaangn.apiserver.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import static com.daangndaangn.apiserver.controller.ApiResult.*;
+
+@RequestMapping("/api/users")
+@RestController
+@RequiredArgsConstructor
+public class UserApiController {
+
+    private final OAuthService oAuthService;
+    private final UserService userService;
+
+    @PostMapping("/join")
+    public ApiResult<UserResponse.JoinResponse> join(@Valid @RequestBody UserRequest.JoinRequest request) {
+        String accessToken = request.getAccessToken();
+        OAuthDto.Response userInfo = oAuthService.getUserInfo(OAuthDto.Request.from(accessToken));
+
+        UserResponse.JoinResponse joinResponse = userService.join(userInfo.getId(),
+                                                                  Email.from(userInfo.getEmail()),
+                                                                  request.getNickname(),
+                                                                  Location.from(request.getLocation()),
+                                                                  request.getProfileUrl());
+
+        return OK(joinResponse);
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/user/UserRequest.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/user/UserRequest.java
@@ -1,0 +1,26 @@
+package com.daangndaangn.apiserver.controller.user;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * 사용자 API 관련 요청
+ */
+public class UserRequest {
+
+    @Getter
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class JoinRequest {
+        @NotNull
+        private String accessToken;
+        @NotNull
+        private String nickname;
+        @NotNull
+        private String location;
+        private String profileUrl;
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/user/UserResponse.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/user/UserResponse.java
@@ -1,0 +1,31 @@
+package com.daangndaangn.apiserver.controller.user;
+
+import com.daangndaangn.apiserver.entity.user.User;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 사용자 API 관련 응답
+ */
+public class UserResponse {
+
+    @Getter
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class JoinResponse {
+        private Long id;
+        private Long oauthId;
+        private String email;
+
+        public static JoinResponse from(User user) {
+            return JoinResponse.builder()
+                    .id(user.getId())
+                    .oauthId(user.getOauthId())
+                    .email(user.getEmail().getAddress())
+                    .build();
+        }
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/product/Product.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/product/Product.java
@@ -2,6 +2,7 @@ package com.daangndaangn.apiserver.entity.product;
 
 import com.daangndaangn.apiserver.entity.AuditingCreateUpdateEntity;
 import com.daangndaangn.apiserver.entity.category.Category;
+import com.daangndaangn.apiserver.entity.user.Location;
 import com.daangndaangn.apiserver.entity.user.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -49,7 +50,7 @@ public class Product extends AuditingCreateUpdateEntity {
     private String sellingType;
 
     @Column(nullable = false, length = 20)
-    private String location;
+    private Location location;
 
     @Column(nullable = false)
     private ProductState state;

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Email.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Email.java
@@ -1,0 +1,47 @@
+package com.daangndaangn.apiserver.entity.user;
+
+import lombok.*;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+
+import static java.util.regex.Pattern.matches;
+
+@ToString
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Embeddable
+@Access(AccessType.FIELD)
+public class Email {
+
+    @Column(name = "email")
+    private String address;
+
+    public String getName() {
+        String[] tokens = address.split("@");
+        return tokens.length == 2 ? tokens[0] : null;
+    }
+
+    public String getDomain() {
+        String[] tokens = address.split("@");
+        return tokens.length == 2 ? tokens[1] : null;
+    }
+
+    public static boolean checkEmailAddress(String address) {
+        return matches("[\\w~\\-.+]+@[\\w~\\-]+(\\.[\\w~\\-]+)+", address);
+    }
+
+    public static Email from(String emailAddress) {
+        if (checkEmailAddress(emailAddress)) {
+            return new Email(emailAddress);
+        }
+
+        throw new RuntimeException("Invalid email address");
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Email.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Email.java
@@ -10,6 +10,9 @@ import javax.persistence.Embeddable;
 
 import static java.util.regex.Pattern.matches;
 
+/**
+ * 사용자의 이메일을 나타내는 Value Object
+ */
 @ToString
 @Getter
 @EqualsAndHashCode
@@ -41,7 +44,7 @@ public class Email {
             return new Email(emailAddress);
         }
 
-        throw new RuntimeException("Invalid email address");
+        throw new IllegalArgumentException("Invalid email address");
     }
 
 }

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Location.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Location.java
@@ -1,0 +1,26 @@
+package com.daangndaangn.apiserver.entity.user;
+
+import lombok.*;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@ToString
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Embeddable
+@Access(AccessType.FIELD)
+public class Location {
+
+    @Column(name = "location")
+    private String address;
+
+    public static Location from(String address) {
+        return new Location(address);
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Location.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Location.java
@@ -7,6 +7,9 @@ import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+/**
+ * 사용자의 위치 정보를 나타내는 Value Object
+ */
 @ToString
 @Getter
 @EqualsAndHashCode

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Role.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/Role.java
@@ -1,0 +1,26 @@
+package com.daangndaangn.apiserver.entity.user;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Role {
+
+    USER("ROLE_USER");
+
+    private final String value;
+
+    public String value() {
+        return value;
+    }
+
+    public static Role from(String name) {
+        for (Role role : Role.values()) {
+            if (role.name().equalsIgnoreCase(name)) {
+                return role;
+            }
+        }
+        return null;
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/User.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/User.java
@@ -50,6 +50,6 @@ public class User extends AuditingCreateUpdateEntity {
 
     public String createApiToken(Jwt jwt, String[] roles) {
         Jwt.Claims claims = Jwt.Claims.of(id, oauthId, nickname, location, manner, email, roles);
-        return jwt.newToken(claims);
+        return jwt.createNewToken(claims);
     }
 }

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/User.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/user/User.java
@@ -1,6 +1,7 @@
 package com.daangndaangn.apiserver.entity.user;
 
 import com.daangndaangn.apiserver.entity.AuditingCreateUpdateEntity;
+import com.daangndaangn.apiserver.security.jwt.Jwt;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,27 +19,37 @@ public class User extends AuditingCreateUpdateEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 50)
-    private String email;
+    @Column(nullable = false)
+    private Long oauthId;
 
-    @Column(nullable = false, length = 20)
+    @Embedded
+    @Column(nullable = false, length = 50)
+    private Email email;
+
+    @Column(length = 20)
     private String nickname;
 
-    @Column(nullable = false, length = 20)
-    private String location;
+    @Column(length = 20)
+    private Location location;
 
     @Column(length = 500)
     private String profileUrl;
 
     @Column(nullable = false)
-    private float manner;
+    private double manner;
 
     @Builder
-    private User(String email, String nickname, String location, String profileUrl) {
+    private User(Long oauthId, Email email, String nickname, Location location, String profileUrl) {
+        this.oauthId = oauthId;
         this.email = email;
         this.nickname = nickname;
         this.location = location;
         this.profileUrl = profileUrl;
-        this.manner = 0.0f;
+        this.manner = 0.0;
+    }
+
+    public String createApiToken(Jwt jwt, String[] roles) {
+        Jwt.Claims claims = Jwt.Claims.of(id, oauthId, nickname, location, manner, email, roles);
+        return jwt.newToken(claims);
     }
 }

--- a/api-server/src/main/java/com/daangndaangn/apiserver/error/NotFoundException.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/error/NotFoundException.java
@@ -1,0 +1,40 @@
+package com.daangndaangn.apiserver.error;
+
+import com.daangndaangn.apiserver.util.MessageUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
+/**
+ * 엔티티를 조회하지 못한 경우 내려주는 Exception
+ *
+ * // 사용 예시
+ * new NotFoundException(User.class, "userId = 12345");
+ * new NotFoundException(Product.class, "userId = 12345", 12345);
+ */
+public class NotFoundException extends ServiceRuntimeException {
+
+    static final String MESSAGE_KEY = "error.notfound";
+    static final String MESSAGE_DETAILS = "error.notfound.details";
+
+    public NotFoundException(Class<?> cls, Object... values) {
+        this(cls.getSimpleName(), values);
+    }
+
+    public NotFoundException(String targetName, Object... values) {
+        super(MESSAGE_KEY, MESSAGE_DETAILS,
+                new String[]{targetName,
+                        (isNotEmpty(values)) ? StringUtils.join(values, ",") : ""}
+        );
+    }
+
+    @Override
+    public String getMessage() {
+        return MessageUtils.getMessage(getDetailKey(), getParams());
+    }
+
+    @Override
+    public String toString() {
+        return MessageUtils.getMessage(getMessageKey());
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/error/ServiceRuntimeException.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/error/ServiceRuntimeException.java
@@ -1,0 +1,22 @@
+package com.daangndaangn.apiserver.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 사용자 정의 예외 최상위 클래스.
+ * 모든 사용자 정의 예외 클래스는 ServiceRuntimeException을 상속받아 구현한다.
+ */
+@Getter
+@AllArgsConstructor
+public abstract class ServiceRuntimeException extends RuntimeException {
+
+    // 발생한 예외 타입에 대한 정보만 내려줄 때 사용할 key
+    private final String messageKey;
+
+    // 발생한 예외에 대해 자세한 정보를 내려줄 때 사용할 key
+    private final String detailKey;
+
+    // 필요 시 에러 메시지에 추가할 parameter
+    private final Object[] params;
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/error/UnauthorizedException.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/error/UnauthorizedException.java
@@ -1,0 +1,27 @@
+package com.daangndaangn.apiserver.error;
+
+import com.daangndaangn.apiserver.util.MessageUtils;
+
+/**
+ * 권한이 없는 API를 호출할 경우 사용하는 Exception
+ */
+public class UnauthorizedException extends ServiceRuntimeException {
+
+    public static final String MESSAGE_KEY = "error.auth";
+    public static final String MESSAGE_DETAIL = "error.auth.details";
+
+    public UnauthorizedException(String message) {
+        super(MESSAGE_KEY, MESSAGE_DETAIL, new String[]{message});
+    }
+
+    @Override
+    public String getMessage() {
+        return MessageUtils.getMessage(getDetailKey(), getParams());
+    }
+
+    @Override
+    public String toString() {
+        return MessageUtils.getMessage(getMessageKey());
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/repository/UserRepository.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.daangndaangn.apiserver.repository;
+
+import com.daangndaangn.apiserver.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByOauthId(Long oauthId);
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/CustomAccessDeniedHandler.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,42 @@
+package com.daangndaangn.apiserver.security;
+
+import com.daangndaangn.apiserver.controller.ApiResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static com.daangndaangn.apiserver.controller.ApiResult.ERROR;
+
+/**
+ * 인가 실패 시 403 응답을 내려주는 Handler
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    static ApiResult<?> E403 = ERROR("Authentication error (cause: forbidden)", HttpStatus.FORBIDDEN);
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setHeader("content-type", "application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(E403));
+        response.getWriter().flush();
+        response.getWriter().close();
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/CustomUnauthorizedHandler.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/CustomUnauthorizedHandler.java
@@ -1,0 +1,40 @@
+package com.daangndaangn.apiserver.security;
+
+import com.daangndaangn.apiserver.controller.ApiResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.daangndaangn.apiserver.controller.ApiResult.ERROR;
+
+/**
+ * 인증 실패 시 401 응답을 내려주는 Handler
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomUnauthorizedHandler implements AuthenticationEntryPoint {
+
+    static ApiResult<?> E401 = ERROR("Authentication error (cause: unauthorized)", HttpStatus.UNAUTHORIZED);
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setHeader("content-type", "application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(E401));
+        response.getWriter().flush();
+        response.getWriter().close();
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/Jwt.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/Jwt.java
@@ -1,0 +1,168 @@
+package com.daangndaangn.apiserver.security.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.daangndaangn.apiserver.entity.user.Email;
+import com.daangndaangn.apiserver.entity.user.Location;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * JWT를 발행하는 클래스
+ */
+@Getter
+public final class Jwt {
+
+    private final String issuer;
+
+    private final String clientSecret;
+
+    private final int expirySeconds;
+
+    private final Algorithm algorithm;
+
+    private final JWTVerifier jwtVerifier;
+
+    public Jwt(String issuer, String clientSecret, int expirySeconds) {
+        this.issuer = issuer;
+        this.clientSecret = clientSecret;
+        this.expirySeconds = expirySeconds;
+        this.algorithm = Algorithm.HMAC512(clientSecret);
+        this.jwtVerifier = JWT.require(algorithm)
+                                .withIssuer(issuer)
+                                .build();
+    }
+
+    public String newToken(Claims claims) {
+        Date now = new Date();
+        JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
+        builder.withIssuer(issuer);
+        builder.withIssuedAt(now);
+
+        if (expirySeconds > 0) {
+            builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
+        }
+
+        builder.withClaim("id", claims.id);
+        builder.withClaim("oauthId", claims.oauthId);
+        builder.withClaim("nickname", claims.nickname);
+        builder.withClaim("location", claims.location.getAddress());
+        builder.withClaim("manner", claims.manner);
+        builder.withClaim("email", claims.email.getAddress());
+        builder.withClaim("profileUrl", claims.profileUrl);
+        builder.withArrayClaim("roles", claims.roles);
+        return builder.sign(algorithm);
+    }
+
+    public String refreshToken(String token) throws JWTVerificationException {
+        Claims claims = verify(token);
+        claims.eraseIat();
+        claims.eraseExp();
+        return newToken(claims);
+    }
+
+    public Claims verify(String token) throws JWTVerificationException  {
+        return new Claims(jwtVerifier.verify(token));
+    }
+
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Claims {
+        Long id;
+        Long oauthId;
+        String nickname;
+        Location location;
+        Double manner;
+        Email email;
+        String profileUrl;
+        String[] roles;
+        Date iat;
+        Date exp;
+
+        Claims(DecodedJWT decodedJWT) {
+            Claim id = decodedJWT.getClaim("id");
+            if (!id.isNull())
+                this.id = id.asLong();
+            Claim oauthId = decodedJWT.getClaim("oauthId");
+            if (!oauthId.isNull())
+                this.oauthId = oauthId.asLong();
+            Claim nickname = decodedJWT.getClaim("nickname");
+            if (!nickname.isNull())
+                this.nickname = nickname.asString();
+            Claim location = decodedJWT.getClaim("location");
+            if (!location.isNull())
+                this.location = Location.from(location.asString());
+            Claim manner = decodedJWT.getClaim("manner");
+            if (!manner.isNull())
+                this.manner = manner.asDouble();
+            Claim email = decodedJWT.getClaim("email");
+            if (!email.isNull())
+                this.email = Email.from(email.asString());
+            Claim profileUrl = decodedJWT.getClaim("profileUrl");
+            if (!profileUrl.isNull())
+                this.profileUrl = profileUrl.asString();
+            Claim roles = decodedJWT.getClaim("roles");
+            if (!roles.isNull())
+                this.roles = roles.asArray(String.class);
+            this.iat = decodedJWT.getIssuedAt();
+            this.exp = decodedJWT.getExpiresAt();
+        }
+
+        public static Claims of(Long id, Long oauthId, String nickname, Location location, Double manner, Email email, String[] roles) {
+            Claims claims = new Claims();
+            claims.id = id;
+            claims.oauthId = oauthId;
+            claims.nickname = nickname;
+            claims.location = location;
+            claims.manner = manner;
+            claims.email = email;
+            claims.roles = roles;
+            return claims;
+        }
+
+        long iat() {
+            return ObjectUtils.isNotEmpty(iat) ? iat.getTime() : -1;
+        }
+
+        long exp() {
+            return ObjectUtils.isNotEmpty(exp) ? exp.getTime() : -1;
+        }
+
+        void eraseIat() {
+            iat = null;
+        }
+
+        void eraseExp() {
+            exp = null;
+        }
+
+        //FIXME: 삭제 예정
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("id", id)
+                .append("oauthId", oauthId)
+                .append("nickname", nickname)
+                .append("location", location)
+                .append("manner", manner)
+                .append("email", email)
+                .append("profileUrl", profileUrl)
+                .append("roles", Arrays.toString(roles))
+                .append("iat", iat)
+                .append("exp", exp)
+                .toString();
+        }
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/Jwt.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/Jwt.java
@@ -45,7 +45,7 @@ public final class Jwt {
                                 .build();
     }
 
-    public String newToken(Claims claims) {
+    public String createNewToken(Claims claims) {
         Date now = new Date();
         JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
         builder.withIssuer(issuer);
@@ -66,11 +66,11 @@ public final class Jwt {
         return builder.sign(algorithm);
     }
 
-    public String refreshToken(String token) throws JWTVerificationException {
+    public String createRefreshToken(String token) throws JWTVerificationException {
         Claims claims = verify(token);
         claims.eraseIat();
         claims.eraseExp();
-        return newToken(claims);
+        return createNewToken(claims);
     }
 
     public Claims verify(String token) throws JWTVerificationException  {

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthentication.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthentication.java
@@ -1,0 +1,43 @@
+package com.daangndaangn.apiserver.security.jwt;
+
+import com.daangndaangn.apiserver.entity.user.Email;
+import com.daangndaangn.apiserver.entity.user.Location;
+import com.daangndaangn.apiserver.entity.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 인증된 사용자를 표현
+ */
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class JwtAuthentication {
+
+    private final Long id;
+
+    private final Long oauthId;
+
+    private final Email email;
+
+    private final String nickname;
+
+    private final Location location;
+
+    private final String profileUrl;
+
+    private final Double manner;
+
+    public static JwtAuthentication from(User user) {
+        return JwtAuthentication.builder()
+                .id(user.getId())
+                .oauthId(user.getOauthId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .location(user.getLocation())
+                .profileUrl(user.getProfileUrl())
+                .manner(user.getManner())
+                .build();
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthenticationProvider.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,62 @@
+package com.daangndaangn.apiserver.security.jwt;
+
+import com.daangndaangn.apiserver.controller.authentication.AuthenticationDto;
+import com.daangndaangn.apiserver.entity.user.Role;
+import com.daangndaangn.apiserver.entity.user.User;
+import com.daangndaangn.apiserver.error.NotFoundException;
+import com.daangndaangn.apiserver.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import static org.apache.commons.lang3.ClassUtils.isAssignable;
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+/**
+ * 사용자 요청으로부터 들어온 인증주체를 검증하는 클래스 (실제 인증 로직 처리 역할)
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    private final Jwt jwt;
+
+    private final UserService userService;
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return isAssignable(JwtAuthenticationToken.class, authentication);
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        JwtAuthenticationToken authenticationToken = (JwtAuthenticationToken) authentication;
+        return createUserAuthentication(authenticationToken.getAuthenticationId());
+    }
+
+    private Authentication createUserAuthentication(Long authenticationId) {
+        try {
+            User user = userService.login(authenticationId);
+            JwtAuthentication jwtAuthentication = JwtAuthentication.from(user);
+            JwtAuthenticationToken authenticationToken =
+                    JwtAuthenticationToken.of(jwtAuthentication, createAuthorityList(Role.USER.value()));
+
+            String apiToken = user.createApiToken(jwt, new String[]{Role.USER.value()});
+            authenticationToken.setDetails(AuthenticationDto.Response.of(apiToken, user));
+
+            return authenticationToken;
+        } catch (NotFoundException e) {
+            throw new UsernameNotFoundException(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            throw new BadCredentialsException(e.getMessage());
+        } catch (DataAccessException e) {
+            throw new AuthenticationServiceException(e.getMessage(), e);
+        }
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthenticationToken.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,66 @@
+package com.daangndaangn.apiserver.security.jwt;
+
+import lombok.ToString;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+/**
+ * SpringSecurity 인증정보(Authentication 구현) 클래스
+ */
+@ToString
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    /**
+     * 인증 주체를 나타낸다. 타입이 Object 라는 것이 중요.
+     * Object인 이유는 로그인 전과 로그인 후의 타입이 다르기 때문이다.
+     * 로그인 전에는 String 타입(accessToken)이고, 로그인 후에는 {@link JwtAuthentication} 타입.
+     */
+    private final Object principal;
+
+    public static JwtAuthenticationToken from(Long principal) {
+        return new JwtAuthenticationToken(principal);
+    }
+
+    public static JwtAuthenticationToken of(Object principal, Collection<? extends GrantedAuthority> authorities) {
+        return new JwtAuthenticationToken(principal, authorities);
+    }
+
+    public Long getAuthenticationId() {
+        return (Long)principal;
+    }
+
+    private JwtAuthenticationToken(Long principal) {
+        super(null);
+        super.setAuthenticated(false);
+
+        this.principal = principal;
+    }
+
+    private JwtAuthenticationToken(Object principal, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        super.setAuthenticated(true);
+
+        this.principal = principal;
+    }
+
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        if (isAuthenticated) {
+            throw new IllegalArgumentException("Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead");
+        }
+        super.setAuthenticated(false);
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    // Not Used
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthenticationTokenFilter.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthenticationTokenFilter.java
@@ -1,0 +1,143 @@
+package com.daangndaangn.apiserver.security.jwt;
+
+import com.daangndaangn.apiserver.entity.user.Email;
+import com.daangndaangn.apiserver.entity.user.Location;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
+/**
+ * HTTP Request-Header 에서 JWT 값을 추출하고, JWT 값이 올바르다면 인증정보 {@link JwtAuthenticationToken}를 생성한다.
+ * 생성된 {@link JwtAuthenticationToken} 인스턴스는 {@link SecurityContextHolder}를 통해 Thread-Local 영역에 저장된다.
+ *
+ * 인증이 완료된  {@link JwtAuthenticationToken}부분 에는 {@link JwtAuthentication} 인스턴스가 set 된다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
+
+    private static final Pattern BEARER = Pattern.compile("^Bearer$", Pattern.CASE_INSENSITIVE);
+
+    private final Jwt jwt;
+
+    private final String headerKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        // SecurityContextHolder 에서 인증정보를 찾을 수 없다면
+        if (isEmpty(SecurityContextHolder.getContext().getAuthentication())) {
+            // HTTP 요청 Header에서 JWT 값 추출
+            String authorizationToken = getAuthorizationToken(request);
+
+            if (isNotEmpty(authorizationToken)) {
+
+                try {
+                    Jwt.Claims claims = verify(authorizationToken);
+                    log.debug("Jwt parse result: {}", claims);
+
+                    // 만료 10분 전일 때
+                    if (canRefresh(claims, 10 * 60 * 1000)) {
+                        String refreshedToken = jwt.refreshToken(authorizationToken);
+                        response.setHeader(headerKey, refreshedToken);
+                    }
+
+                    Long id = claims.id;
+                    Long oauthId = claims.oauthId;
+                    Email email = claims.email;
+                    String nickname = claims.nickname;
+                    Location location = claims.location;
+                    String profileUrl = claims.profileUrl;
+                    Double manner = claims.manner;
+
+                    List<GrantedAuthority> authorities = getAuthorities(claims);
+
+                    if (nonNull(id) && nonNull(oauthId) && authorities.size() > 0) {
+
+                        JwtAuthentication principal = JwtAuthentication.builder()
+                                                                        .id(id)
+                                                                        .oauthId(oauthId)
+                                                                        .email(email)
+                                                                        .nickname(nickname)
+                                                                        .location(location)
+                                                                        .profileUrl(profileUrl)
+                                                                        .manner(manner)
+                                                                        .build();
+
+                        JwtAuthenticationToken authentication = JwtAuthenticationToken.of(principal, authorities);
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    }
+
+                } catch (Exception e) {
+                    log.warn("Jwt processing failed: {}", e.getMessage());
+                }
+
+            }
+
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private boolean canRefresh(Jwt.Claims claims, long refreshRangeMillis) {
+        long exp = claims.exp();
+        if (exp > 0) {
+            long remain = exp - System.currentTimeMillis();
+            return remain < refreshRangeMillis;
+        }
+        return false;
+    }
+
+    private List<GrantedAuthority> getAuthorities(Jwt.Claims claims) {
+        String[] roles = claims.roles;
+        return isEmpty(roles) ? Collections.emptyList() : Arrays.stream(roles)
+                                                                .map(SimpleGrantedAuthority::new)
+                                                                .collect(toList());
+    }
+
+    private String getAuthorizationToken(HttpServletRequest request) {
+        String token = request.getHeader(headerKey);
+        if (isNotEmpty(token)) {
+            try {
+                token = URLDecoder.decode(token, "UTF-8");
+                String[] tokenParts = token.split(" ");
+
+                if (tokenParts.length == 2) {
+                    String scheme = tokenParts[0];  //BEARER 부분
+                    String credentials = tokenParts[1]; //실제 토큰 부분
+                    return BEARER.matcher(scheme).matches() ? credentials : null;
+                }
+
+            } catch (UnsupportedEncodingException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+
+        return null;
+    }
+
+    private Jwt.Claims verify(String token) {
+        return jwt.verify(token);
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthenticationTokenFilter.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/jwt/JwtAuthenticationTokenFilter.java
@@ -59,7 +59,7 @@ public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
 
                     // 만료 10분 전일 때
                     if (canRefresh(claims, 10 * 60 * 1000)) {
-                        String refreshedToken = jwt.refreshToken(authorizationToken);
+                        String refreshedToken = jwt.createRefreshToken(authorizationToken);
                         response.setHeader(headerKey, refreshedToken);
                     }
 

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/oauth/KakaoOAuthService.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/oauth/KakaoOAuthService.java
@@ -1,0 +1,62 @@
+package com.daangndaangn.apiserver.security.oauth;
+
+import com.daangndaangn.apiserver.configure.OAuthConfigure;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 클라이언트로부터 OAuth accessToken을 받아 OAuth Server로부터 사용자 정보를 조회하는 클래스
+ *
+ * 구현체인 KakaoOAuthService는 카카오 API 스펙을 따른다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService implements OAuthService {
+
+    private final RestTemplate restTemplate;
+
+    private final OAuthConfigure oAuthConfigure;
+
+    @Override
+    public OAuthDto.Response getUserInfo(OAuthDto.Request request) {
+
+        HttpEntity authRequest = createAuthRequest(request);
+        String requestUrl = oAuthConfigure.getUrl();
+
+        ResponseEntity<OAuthDto.Response> oauthResponse
+                = restTemplate.exchange(requestUrl, HttpMethod.GET, authRequest, OAuthDto.Response.class);
+
+        log.info("response body = {}", oauthResponse.getBody());
+
+        return oauthResponse.getBody();
+    }
+
+    /**
+     * HttpHeader key: Authorization
+     * HttpHeader value: Bearer ${ACCESS_TOKEN}
+     *
+     * @return Authorization: Bearer ${ACCESS_TOKEN}
+     */
+    private HttpEntity createAuthRequest(OAuthDto.Request authRequest) {
+        String headerValue = createRequestHeader(authRequest.getAccessToken());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(oAuthConfigure.getHeaderKey(), headerValue);
+
+        return new HttpEntity(headers);
+    }
+
+    /**
+     * @return Bearer ${ACCESS_TOKEN}
+     */
+    private String createRequestHeader(String accessToken) {
+        return String.format("%s %s", oAuthConfigure.getHeaderValue(), accessToken);
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/oauth/OAuthDto.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/oauth/OAuthDto.java
@@ -1,0 +1,49 @@
+package com.daangndaangn.apiserver.security.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+/**
+ * OAuthDto.Request: OAuthService에 사용자 정보를 요청하기 위해 필요한 parameter(ex. accessToken)
+ * OAuthDto.Response: OAuthService의 사용자 정보 응답으로부터 사용하고자 하는 값
+ */
+public class OAuthDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class Request {
+
+        private String accessToken;
+
+        public static OAuthDto.Request from(String accessToken) {
+            return new OAuthDto.Request(accessToken);
+        }
+    }
+
+    /**
+     * json response
+     *
+     * {
+     *     "id": 123,
+     *     "kakao_account:": {
+     *         "email": "test@gmail.com"
+     *     }
+     * }
+     */
+    @Getter
+    @ToString   //FIXME: ToString은 결과 확인용으로 향후 제거할 예정입니다.
+    public static class Response {
+
+        private Long id;
+        private String email;
+
+        @JsonProperty("kakao_account")
+        private void getUserEmail(Map<String, String> kakaoAccountInfo) {
+            this.email = kakaoAccountInfo.get("email");
+        }
+    }
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/security/oauth/OAuthService.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/security/oauth/OAuthService.java
@@ -1,0 +1,8 @@
+package com.daangndaangn.apiserver.security.oauth;
+
+/**
+ * 클라이언트로부터 OAuth accessToken을 받아 OAuth Server로부터 사용자 정보를 조회하는 역할
+ */
+public interface OAuthService {
+    OAuthDto.Response getUserInfo(OAuthDto.Request request);
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/service/user/UserService.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/service/user/UserService.java
@@ -1,0 +1,13 @@
+package com.daangndaangn.apiserver.service.user;
+
+import com.daangndaangn.apiserver.controller.user.UserResponse;
+import com.daangndaangn.apiserver.entity.user.Email;
+import com.daangndaangn.apiserver.entity.user.Location;
+import com.daangndaangn.apiserver.entity.user.User;
+
+public interface UserService {
+
+    UserResponse.JoinResponse join(Long oauthId, Email email, String nickname, Location location, String profileUrl);
+
+    User login(Long oauthId);
+}

--- a/api-server/src/main/java/com/daangndaangn/apiserver/service/user/UserServiceImpl.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/service/user/UserServiceImpl.java
@@ -1,0 +1,46 @@
+package com.daangndaangn.apiserver.service.user;
+
+import com.daangndaangn.apiserver.controller.user.UserResponse;
+import com.daangndaangn.apiserver.entity.user.Email;
+import com.daangndaangn.apiserver.entity.user.Location;
+import com.daangndaangn.apiserver.entity.user.User;
+import com.daangndaangn.apiserver.error.NotFoundException;
+import com.daangndaangn.apiserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public UserResponse.JoinResponse join(Long oauthId, Email email, String nickname, Location location, String profileUrl) {
+
+        User user = User.builder()
+                        .oauthId(oauthId)
+                        .email(email)
+                        .nickname(nickname)
+                        .location(location)
+                        .profileUrl(profileUrl)
+                        .build();
+
+        return convertToDto(userRepository.save(user));
+    }
+
+    @Override
+    public User login(Long oauthId) {
+        return userRepository.findByOauthId(oauthId)
+                .orElseThrow(() -> new NotFoundException(User.class, String.format("oauthId = %s", oauthId)));
+    }
+
+    private UserResponse.JoinResponse convertToDto(User user) {
+        return UserResponse.JoinResponse.from(user);
+    }
+}
+

--- a/api-server/src/main/java/com/daangndaangn/apiserver/util/MessageUtils.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/util/MessageUtils.java
@@ -1,0 +1,35 @@
+package com.daangndaangn.apiserver.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.context.support.MessageSourceAccessor;
+
+/**
+ * MessageSourceAccessor를 사용하기 위한 유틸클래스
+ *
+ * 사용자 정의 에러 메시지를 내려주는 역할
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MessageUtils {
+
+    private static MessageSourceAccessor messageSourceAccessor;
+
+    public static String getMessage(String key) {
+        if (ObjectUtils.isEmpty(messageSourceAccessor)) {
+            throw new IllegalStateException("MessageSourceAccessor is not initialized.");
+        }
+        return messageSourceAccessor.getMessage(key);
+    }
+
+    public static String getMessage(String key, Object... params) {
+        if (ObjectUtils.isEmpty(messageSourceAccessor)) {
+            throw new IllegalStateException("MessageSourceAccessor is not initialized.");
+        }
+        return messageSourceAccessor.getMessage(key, params);
+    }
+
+    public static void setMessageSourceAccessor(MessageSourceAccessor messageSourceAccessor) {
+        MessageUtils.messageSourceAccessor = messageSourceAccessor;
+    }
+}

--- a/api-server/src/main/resources/application.yml
+++ b/api-server/src/main/resources/application.yml
@@ -7,3 +7,15 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+jwt:
+  header: api_key
+  issuer: daangn-server
+  clientSecret: daangn-server
+  expirySeconds: 7200 # 2시간
+
+oauth:
+  kakao:
+    headerKey: Authorization
+    headerValue: Bearer
+    url: https://kapi.kakao.com/v2/user/me

--- a/api-server/src/main/resources/messages.properties
+++ b/api-server/src/main/resources/messages.properties
@@ -1,0 +1,4 @@
+error.auth=AuthenticationFailed
+error.auth.details=Authentication error (cause: {0})
+error.notfound=NotFound
+error.notfound.details=Could not found ''{0}'' with query values ({1})

--- a/api-server/src/main/resources/schema.sql
+++ b/api-server/src/main/resources/schema.sql
@@ -9,7 +9,7 @@ DROP TABLE IF EXISTS sale_reviews CASCADE;
 CREATE TABLE users
 (
     id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
-    oauth_id            bigint          NOT NULL COMMENt 'OAUTH ID',
+    oauth_id            bigint          NOT NULL COMMENT 'oauth id',
     email               varchar(50)     NOT NULL COMMENT '사용자 이메일',
     nickname            varchar(20)     NOT NULL COMMENT '닉네임',
     location            varchar(50)     NOT NULL COMMENT '지역',

--- a/api-server/src/main/resources/schema.sql
+++ b/api-server/src/main/resources/schema.sql
@@ -9,11 +9,12 @@ DROP TABLE IF EXISTS sale_reviews CASCADE;
 CREATE TABLE users
 (
     id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
+    oauth_id            bigint          NOT NULL COMMENt 'OAUTH ID',
     email               varchar(50)     NOT NULL COMMENT '사용자 이메일',
     nickname            varchar(20)     NOT NULL COMMENT '닉네임',
     location            varchar(50)     NOT NULL COMMENT '지역',
     profile_url         varchar(500)    DEFAULT NULL COMMENT '프로필 사진',
-    manner              float           NOT NULL DEFAULT 0 COMMENT '매너온도',
+    manner              double          NOT NULL DEFAULT 0 COMMENT '매너온도',
     created_at          datetime        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
     updated_at          datetime        DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
     PRIMARY KEY (id),

--- a/api-server/src/test/java/com/daangndaangn/apiserver/controller/HealthCheckRestControllerTest.java
+++ b/api-server/src/test/java/com/daangndaangn/apiserver/controller/HealthCheckRestControllerTest.java
@@ -1,0 +1,43 @@
+package com.daangndaangn.apiserver.controller;
+
+import com.daangndaangn.apiserver.security.WithMockJwtAuthentication;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HealthCheckRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockJwtAuthentication
+    @DisplayName("회원 인증이 필요한 API는 @WithMockJwtAuthentication을 사용해서 호출할 수 있다.")
+    void getSystemTimeMillisWithUserSuccessTest() throws Exception {
+        ResultActions result = mockMvc.perform(
+                get("/api/hcheck/with-user")
+                    .accept(MediaType.APPLICATION_JSON)
+        );
+
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(HealthCheckRestController.class))
+                .andExpect(handler().methodName("getSystemTimeMillisWithUser"))
+                .andExpect(jsonPath("$.success", is(true)));
+    }
+}

--- a/api-server/src/test/java/com/daangndaangn/apiserver/security/WithMockJwtAuthentication.java
+++ b/api-server/src/test/java/com/daangndaangn/apiserver/security/WithMockJwtAuthentication.java
@@ -1,0 +1,27 @@
+package com.daangndaangn.apiserver.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockJwtAuthenticationSecurityContextFactory.class)
+public @interface WithMockJwtAuthentication {
+
+    long id() default 1L;
+
+    long oauthId() default 12315L;
+
+    String email() default "tester00@gmail.com";
+
+    String nickname() default "tester00";
+
+    String location() default "서울시 마포구";
+
+    String profileUrl() default "http:localhost:8080/profile/url";
+
+    double manner() default 36.5;
+
+    String role() default "ROLE_USER";
+}

--- a/api-server/src/test/java/com/daangndaangn/apiserver/security/WithMockJwtAuthenticationSecurityContextFactory.java
+++ b/api-server/src/test/java/com/daangndaangn/apiserver/security/WithMockJwtAuthenticationSecurityContextFactory.java
@@ -1,0 +1,32 @@
+package com.daangndaangn.apiserver.security;
+
+import com.daangndaangn.apiserver.entity.user.Email;
+import com.daangndaangn.apiserver.entity.user.Location;
+import com.daangndaangn.apiserver.security.jwt.JwtAuthentication;
+import com.daangndaangn.apiserver.security.jwt.JwtAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+public class WithMockJwtAuthenticationSecurityContextFactory implements WithSecurityContextFactory<WithMockJwtAuthentication> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockJwtAuthentication annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        JwtAuthentication principal = JwtAuthentication.builder()
+                .id(annotation.id())
+                .oauthId(annotation.oauthId())
+                .email(Email.from(annotation.email()))
+                .nickname(annotation.nickname())
+                .location(Location.from(annotation.location()))
+                .profileUrl(annotation.profileUrl())
+                .manner(annotation.manner()).build();
+
+        JwtAuthenticationToken authentication = JwtAuthenticationToken.of(principal, createAuthorityList(annotation.role()));
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/api-server/src/test/java/com/daangndaangn/apiserver/security/jwt/JwtTest.java
+++ b/api-server/src/test/java/com/daangndaangn/apiserver/security/jwt/JwtTest.java
@@ -1,0 +1,90 @@
+package com.daangndaangn.apiserver.security.jwt;
+
+import com.daangndaangn.apiserver.entity.user.Email;
+import com.daangndaangn.apiserver.entity.user.Location;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.Thread.sleep;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JwtTest {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private Jwt jwt;
+
+    @BeforeAll
+    void setUp() {
+        String issuer = "daangn-server";
+        String clientSecret = "Rel5Bjce6MajBo08qgkNgYaTuzvJe6iwnBFhsD11";
+        int expirySeconds = 10;
+        jwt = new Jwt(issuer, clientSecret, expirySeconds);
+    }
+
+    @Test
+    void JWT_토큰을_생성하고_복호화_할수있다() {
+        Jwt.Claims claims = Jwt.Claims.of(1L,
+                                        12312312L,
+                                        "tester",
+                                        Location.from("Seoul"),
+                                        0.0,
+                                        Email.from("test@gmail.com"),
+                                        new String[]{"ROLE_USER"});
+
+        String encodedJWT = jwt.newToken(claims);
+        log.info("encodedJWT: {}", encodedJWT);
+
+        Jwt.Claims decodedJWT = jwt.verify(encodedJWT);
+        log.info("decodedJWT: {}", decodedJWT);
+
+        assertThat(claims.id).isEqualTo(decodedJWT.id);
+        assertThat(claims.oauthId).isEqualTo(decodedJWT.oauthId);
+        assertThat(claims.nickname).isEqualTo(decodedJWT.nickname);
+        assertThat(claims.location).isEqualTo(decodedJWT.location);
+        assertThat(claims.manner).isEqualTo(decodedJWT.manner);
+        assertThat(claims.email).isEqualTo(decodedJWT.email);
+        assertArrayEquals(claims.roles, decodedJWT.roles);
+    }
+
+    @Test
+    void JWT_토큰을_리프레시_할수있다() throws Exception {
+        if (jwt.getExpirySeconds() > 0) {
+            Jwt.Claims claims = Jwt.Claims.of(1L,
+                    12312312L,
+                    "tester",
+                    Location.from("Seoul"),
+                    0.0,
+                    Email.from("test@gmail.com"),
+                    new String[]{"ROLE_USER"});
+
+            String encodedJWT = jwt.newToken(claims);
+            log.info("encodedJWT: {}", encodedJWT);
+
+            // 1초 대기 후 토큰 갱신
+            sleep(1_000L);
+
+            String encodedRefreshedJWT = jwt.refreshToken(encodedJWT);
+            log.info("encodedRefreshedJWT: {}", encodedRefreshedJWT);
+
+            assertThat(encodedJWT).isNotEqualTo(encodedRefreshedJWT);
+
+            Jwt.Claims oldJwt = jwt.verify(encodedJWT);
+            Jwt.Claims newJwt = jwt.verify(encodedRefreshedJWT);
+
+            long oldExp = oldJwt.exp();
+            long newExp = newJwt.exp();
+
+            // 1초 후에 토큰을 갱신했으므로, 새로운 토큰의 만료시각이 1초 이후임
+            assertThat(newExp >= oldExp + 1_000L).isEqualTo(true);
+
+            log.info("oldJwt: {}", oldJwt);
+            log.info("newJwt: {}", newJwt);
+        }
+    }
+}

--- a/api-server/src/test/java/com/daangndaangn/apiserver/security/jwt/JwtTest.java
+++ b/api-server/src/test/java/com/daangndaangn/apiserver/security/jwt/JwtTest.java
@@ -37,7 +37,7 @@ class JwtTest {
                                         Email.from("test@gmail.com"),
                                         new String[]{"ROLE_USER"});
 
-        String encodedJWT = jwt.newToken(claims);
+        String encodedJWT = jwt.createNewToken(claims);
         log.info("encodedJWT: {}", encodedJWT);
 
         Jwt.Claims decodedJWT = jwt.verify(encodedJWT);
@@ -63,13 +63,13 @@ class JwtTest {
                     Email.from("test@gmail.com"),
                     new String[]{"ROLE_USER"});
 
-            String encodedJWT = jwt.newToken(claims);
+            String encodedJWT = jwt.createNewToken(claims);
             log.info("encodedJWT: {}", encodedJWT);
 
             // 1초 대기 후 토큰 갱신
             sleep(1_000L);
 
-            String encodedRefreshedJWT = jwt.refreshToken(encodedJWT);
+            String encodedRefreshedJWT = jwt.createRefreshToken(encodedJWT);
             log.info("encodedRefreshedJWT: {}", encodedRefreshedJWT);
 
             assertThat(encodedJWT).isNotEqualTo(encodedRefreshedJWT);

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ subprojects {
 		developmentOnly 'org.springframework.boot:spring-boot-devtools'
 		implementation 'org.springframework.boot:spring-boot-starter'
 		implementation 'org.springframework.boot:spring-boot-starter-test'
+		implementation 'org.springframework.boot:spring-boot-starter-validation'
 		implementation group: 'org.apache.commons', name: 'commons-lang3'
 
 		//querydsl 관련 추가


### PR DESCRIPTION
#8 

## 작업 내용

- 회원가입 API, 로그인 API, JWT 적용을 위해 아래 작업들 진행
  - SpringSecurity 적용
  - API 응답 스펙 정의
  - OAuthService 작업 
  - User 도메인 작업
    - Email, Location 필드 별도로 분리(String필드와  혼용 방지)
  - 사용자 정의 예외 작업
    - MessageSource 적용
  - JWT Bean 작업
  - 로그인 API 완성
  - 회원가입 API 완성

## 공유할 사항

- 사용자 정의 예외 관련 자세한 내용은  #10 에 기입해놓았습니다.
- 로그인 API, 회원가입 API 명세도 [Wiki API 명세](https://github.com/daangn-daangn/daangn-server/wiki/API-%EB%AA%85%EC%84%B8)에 기입해놓았습니다.
- 클래스의 역할에 대해 최대한 주석으로 기입해놓았습니다. 이해안되는 부분이나 의견주실 부분 코멘트 주시면 감사하겠습니다
