### PR TITLE
#17 - PR 리뷰 반영

### DIFF
--- a/api-server/src/main/java/com/daangndaangn/apiserver/controller/product/ProductController.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/controller/product/ProductController.java
@@ -14,10 +14,10 @@ import java.util.List;
 
 import static com.daangndaangn.apiserver.controller.ApiResult.OK;
 
-@RequestMapping("/api/product")
+@RequestMapping("/api/products")
 @RestController
 @RequiredArgsConstructor
-public class ProductApiController {
+public class ProductController {
 
     private final ProductService productService;
 
@@ -29,27 +29,25 @@ public class ProductApiController {
     }
 
     @GetMapping("/{productId}")
-    public ApiResult<ProductResponse.GetResponse> getProduct(@PathVariable("productId") Long productId){
+    public ApiResult<ProductResponse.GetResponse> getProduct(@PathVariable("productId") Long productId) {
         ProductResponse.GetResponse getResponse = productService.getProduct(productId);
         return OK(getResponse);
     }
 
-    @GetMapping("/list")
-    public ApiResult<List<ProductResponse.GetListResponse>> getProductList(Pageable pageable, @AuthenticationPrincipal JwtAuthentication authentication){
-        Long userId = authentication.getId();
-        return OK(productService.getProductList(userId, pageable));
-    }
-
-    @GetMapping("/list/filter")
+    @GetMapping
     public ApiResult<List<ProductResponse.GetListResponse>> getProductListFilter(
-            @RequestParam(value = "keyword", required = false) String keyword, @RequestParam(value = "minPrice", defaultValue = "0", required = false) Long minPrice, @RequestParam(value = "maxPrice", required = false) Long maxPrice,
-            @RequestParam(value = "category", required = false) Long category, Pageable pageable, @AuthenticationPrincipal JwtAuthentication authentication){
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "minPrice", defaultValue = "0", required = false) Long minPrice,
+            @RequestParam(value = "maxPrice", required = false) Long maxPrice,
+            @RequestParam(value = "category", required = false) Long category,
+            Pageable pageable,
+            @AuthenticationPrincipal JwtAuthentication authentication) {
         Long userId = authentication.getId();
-        return OK(productService.getProductListFilter(keyword, minPrice, maxPrice, category, pageable, userId));
+        return OK(productService.getProductList(keyword, minPrice, maxPrice, category, userId, pageable));
     }
 
     @PutMapping("/{productId}")
-    public ApiResult updateProduct(@PathVariable("productId") Long productId, @Valid @RequestBody ProductRequest.CreateRequest request, @AuthenticationPrincipal JwtAuthentication authentication){
+    public ApiResult updateProduct(@PathVariable("productId") Long productId, @Valid @RequestBody ProductRequest.CreateRequest request, @AuthenticationPrincipal JwtAuthentication authentication) {
         String title = request.getTitle();
         String name = request.getName();
         String description = request.getDescription();
@@ -61,7 +59,7 @@ public class ProductApiController {
     }
 
     @DeleteMapping("/{productId}")
-    public ApiResult deleteProduct(@PathVariable("productId") Long productId, @AuthenticationPrincipal JwtAuthentication authentication){
+    public ApiResult deleteProduct(@PathVariable("productId") Long productId, @AuthenticationPrincipal JwtAuthentication authentication) {
         Long userId = authentication.getId();
         productService.deleteProduct(productId, userId);
         return OK();

--- a/api-server/src/main/java/com/daangndaangn/apiserver/entity/product/Product.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/entity/product/Product.java
@@ -36,7 +36,7 @@ public class Product extends AuditingCreateUpdateEntity {
     private String name;
 
     @Column(nullable = false)
-    private long price;
+    private Long price;
 
     @Column(nullable = false, length = 100)
     private String title;
@@ -57,7 +57,7 @@ public class Product extends AuditingCreateUpdateEntity {
     private String thumbNailImage;
 
 
-    @OneToMany(mappedBy = "product",cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProductImage> productImageList = new ArrayList<>();
 
     @Builder
@@ -91,7 +91,7 @@ public class Product extends AuditingCreateUpdateEntity {
 //        }
     }
 
-    public void updateInfo(String title, String name, Category category, Long price, String description){
+    public void updateInfo(String title, String name, Category category, Long price, String description) {
         this.title = title;
         this.name = name;
         this.category = category;
@@ -99,7 +99,7 @@ public class Product extends AuditingCreateUpdateEntity {
         this.description = description;
     }
 
-    public void updateState(ProductState state){
+    public void updateState(ProductState state) {
         this.state = state;
     }
 }

--- a/api-server/src/main/java/com/daangndaangn/apiserver/repository/product/ProductCustom.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/repository/product/ProductCustom.java
@@ -7,6 +7,5 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ProductCustom {
-    List<Product> findAllProductByLocation(Location location, Pageable pageable);
-    List<Product> findAllProductByFilter(String keyword, Long minPrice, Long maxPrice, Long categoryId, Location location, Pageable pageable);
+    List<Product> findAllProduct(String keyword, Long minPrice, Long maxPrice, Long categoryId, Location location, Pageable pageable);
 }

--- a/api-server/src/main/java/com/daangndaangn/apiserver/repository/product/ProductRepositoryImpl.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/repository/product/ProductRepositoryImpl.java
@@ -13,56 +13,55 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 @RequiredArgsConstructor
-public class ProductRepositoryImpl implements ProductCustom{
+public class ProductRepositoryImpl implements ProductCustom {
 
     private static final QProduct qProduct = QProduct.product;
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Product> findAllProductByLocation(Location location, Pageable pageable) {
-
-        return jpaQueryFactory.select(qProduct)
-                .from(qProduct)
-                .join(qProduct.category).fetchJoin()
-                .where(
-                        qProduct.location.eq(location)
-                                .and(qProduct.state.eq(ProductState.FOR_SALE)))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-    }
-
-    @Override
-    public List<Product> findAllProductByFilter(String keyword, Long minPrice, Long maxPrice, Long categoryId, Location location, Pageable pageable) {
+    public List<Product> findAllProduct(String keyword, Long minPrice, Long maxPrice, Long categoryId, Location location, Pageable pageable) {
         return jpaQueryFactory.select(qProduct)
                 .from(qProduct)
                 .join(qProduct.category).fetchJoin()
                 .where(
                         this.eqKeyword(keyword),
                         this.eqCategory(categoryId),
+                        this.eqLocation(location),
                         this.rangePrice(minPrice, maxPrice),
-                        qProduct.location.eq(location)
-                        .and(qProduct.state.eq(ProductState.FOR_SALE)))
+                        qProduct.state.eq(ProductState.FOR_SALE))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
     }
 
-    private BooleanExpression eqKeyword(String keyword){
-        if(StringUtils.isEmpty(keyword)){
+    private BooleanExpression eqKeyword(String keyword) {
+        if (StringUtils.isEmpty(keyword)) {
             return null;
         }
         return qProduct.title.contains(keyword);
     }
 
-    private BooleanExpression rangePrice(Long minPrice, Long maxPrice){
-        if(minPrice == null && maxPrice == null) return null;
-        if(minPrice != null && maxPrice == null) return qProduct.price.goe(minPrice);
+    private BooleanExpression eqLocation(Location location) {
+        if (location == null) {
+            return null;
+        }
+        return qProduct.location.eq(location);
+    }
+
+    private BooleanExpression rangePrice(Long minPrice, Long maxPrice) {
+        if (minPrice == null && maxPrice == null) {
+            return null;
+        }
+
+        if (minPrice != null && maxPrice == null) {
+            return qProduct.price.goe(minPrice);
+        }
+
         return qProduct.price.between(minPrice, maxPrice);
     }
 
-    private BooleanExpression eqCategory(Long categoryId){
-        if(categoryId == null){
+    private BooleanExpression eqCategory(Long categoryId) {
+        if (categoryId == null) {
             return null;
         }
         return qProduct.category.id.eq(categoryId);

--- a/api-server/src/main/java/com/daangndaangn/apiserver/service/product/ProductService.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/service/product/ProductService.java
@@ -14,8 +14,7 @@ public interface ProductService {
     */
     ProductResponse.GetResponse getProduct(Long productId);
     ProductResponse.CreateResponse createProduct(ProductRequest.CreateRequest request, Long userId);
-    List<ProductResponse.GetListResponse> getProductList(Long userId, Pageable pageable);
-    List<ProductResponse.GetListResponse> getProductListFilter(String keyword, Long minPrice, Long maxPrice, Long categoryId, Pageable pageable, Long userId);
+    List<ProductResponse.GetListResponse> getProductList(String keyword, Long minPrice, Long maxPrice, Long categoryId, Long userId, Pageable pageable);
 
 
     /*
@@ -26,8 +25,7 @@ public interface ProductService {
     //생성
     Product createProduct(String title, String name, Long categoryId, Long price, String description, List<String> imgUrlList, Long userId);
     //복수 조회 with 조건
-    List<Product> getProductListWithFilter(String keyword, Long minPrice, Long maxPrice, Long categoryId, Pageable pageable, Long userId);
-    List<Product> getProductListWithLocation(Long userId, Pageable pageable);
+    List<Product> findProductList(String keyword, Long minPrice, Long maxPrice, Long categoryId, Long userId, Pageable pageable);
     /*
     For 공용
     */

--- a/api-server/src/main/java/com/daangndaangn/apiserver/service/product/ProductServiceImpl.java
+++ b/api-server/src/main/java/com/daangndaangn/apiserver/service/product/ProductServiceImpl.java
@@ -8,6 +8,7 @@ import com.daangndaangn.apiserver.entity.product.ProductState;
 import com.daangndaangn.apiserver.entity.user.Location;
 import com.daangndaangn.apiserver.entity.user.User;
 import com.daangndaangn.apiserver.error.NotFoundException;
+import com.daangndaangn.apiserver.error.UnauthorizedException;
 import com.daangndaangn.apiserver.repository.product.ProductRepository;
 import com.daangndaangn.apiserver.service.category.CategoryService;
 import com.daangndaangn.apiserver.service.user.UserService;
@@ -23,7 +24,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
-public class ProductServiceImpl implements ProductService{
+public class ProductServiceImpl implements ProductService {
 
     private final ProductRepository productRepository;
     private final CategoryService categoryService;
@@ -31,47 +32,39 @@ public class ProductServiceImpl implements ProductService{
 
     @Override
     public Product findProduct(Long productId) {
+        Preconditions.checkArgument(productId != null, "productId 값은 필수입니다.");
         return productRepository.findById(productId)
                 .orElseThrow(() -> new NotFoundException(Product.class, String.format("productId = %s", productId)));
     }
 
     @Override
-    public List<ProductResponse.GetListResponse> getProductList(Long userId, Pageable pageable){
-        return this.getProductListWithLocation(userId, pageable).stream()
+    public List<ProductResponse.GetListResponse> getProductList(String keyword, Long minPrice, Long maxPrice, Long categoryId, Long userId, Pageable pageable) {
+        return this.findProductList(keyword, minPrice, maxPrice, categoryId, userId, pageable).stream()
                 .map(this::convertToDtoList)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<Product> getProductListWithLocation(Long userId, Pageable pageable) {
+    public List<Product> findProductList(String keyword, Long minPrice, Long maxPrice, Long categoryId, Long userId, Pageable pageable) {
+        Preconditions.checkArgument(userId != null, "userId 값은 필수입니다.");
+//        Preconditions.checkArgument(minPrice < maxPrice, "유효하지 않는 범위입니다.");
         Location location = userService.findUser(userId).getLocation();
-        return productRepository.findAllProductByLocation(location, pageable);
-    }
 
-    @Override
-    public List<ProductResponse.GetListResponse> getProductListFilter(String keyword, Long minPrice, Long maxPrice, Long categoryId, Pageable pageable, Long userId){
-        return this.getProductListWithFilter(keyword, minPrice, maxPrice, categoryId, pageable, userId).stream()
-                .map(this::convertToDtoList)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public List<Product> getProductListWithFilter(String keyword, Long minPrice, Long maxPrice, Long categoryId, Pageable pageable, Long userId){
-        Preconditions.checkArgument(minPrice < maxPrice, "유효하지 않는 범위입니다.");
-        Location location = userService.findUser(userId).getLocation();
-        return productRepository.findAllProductByFilter(keyword, minPrice, maxPrice, categoryId, location, pageable);
+        return productRepository.findAllProduct(keyword, minPrice, maxPrice, categoryId, location, pageable);
     }
 
 
     @Override
-    public ProductResponse.GetResponse getProduct(Long productId){
+    public ProductResponse.GetResponse getProduct(Long productId) {
         Product product = this.findProduct(productId);
         return convertToDto(product);
     }
 
     @Override
     @Transactional
-    public Product createProduct(String title, String name, Long categoryId, Long price, String description, List<String> imgUrlList, Long userId){
+    public Product createProduct(String title, String name, Long categoryId, Long price, String description, List<String> imgUrlList, Long userId) {
+        Preconditions.checkArgument(userId != null, "userId 값은 필수입니다.");
+        Preconditions.checkArgument(categoryId != null, "categoryId 값은 필수입니다.");
         Category category = categoryService.findCategory(categoryId);
         User user = userService.findUser(userId);
         Product product = Product.builder()
@@ -88,6 +81,7 @@ public class ProductServiceImpl implements ProductService{
                 .build();
         return productRepository.save(product);
     }
+
     @Override
     @Transactional
     public ProductResponse.CreateResponse createProduct(ProductRequest.CreateRequest request, Long userId) {
@@ -102,25 +96,29 @@ public class ProductServiceImpl implements ProductService{
 
     @Override
     @Transactional
-    public void updateProduct(Long productId, String title, String name, Long categoryId, Long price, String description, Long userId){
+    public void updateProduct(Long productId, String title, String name, Long categoryId, Long price, String description, Long userId) {
+        Preconditions.checkArgument(productId != null, "productId 값은 필수입니다.");
+        Preconditions.checkArgument(userId != null, "userId 값은 필수입니다.");
         Product product = this.findProduct(productId);
-        if(product.getSeller().getId() != userId){
-            throw new  NotFoundException(Product.class, String.format("productId = %s", productId));
-        }
+        isSeller(userId, product.getSeller().getId());
         Category category = categoryService.findCategory(categoryId);
         product.updateInfo(title, name, category, price, description);
-        productRepository.save(product);
     }
 
     @Override
     @Transactional
     public void deleteProduct(Long productId, Long userId) {
+        Preconditions.checkArgument(productId != null, "productId 값은 필수입니다.");
+        Preconditions.checkArgument(userId != null, "userId 값은 필수입니다.");
         Product product = this.findProduct(productId);
-        if(product.getSeller().getId() != userId){
-            throw new  NotFoundException(Product.class, String.format("productId = %s", productId));
-        }
+        isSeller(userId, product.getSeller().getId());
         product.updateState(ProductState.DELETED);
-        productRepository.save(product);
+    }
+
+    private void isSeller(Long userId, Long sellerId) {
+        if (userId != sellerId) {
+            throw new UnauthorizedException("물품 접근 권한이 없습니다.");
+        }
     }
 
     private ProductResponse.GetResponse convertToDto(Product product) {
@@ -130,4 +128,5 @@ public class ProductServiceImpl implements ProductService{
     private ProductResponse.GetListResponse convertToDtoList(Product product) {
         return ProductResponse.GetListResponse.from(product);
     }
+
 }

--- a/api-server/src/test/java/com/daangndaangn/apiserver/service/product/ProductServiceTest.java
+++ b/api-server/src/test/java/com/daangndaangn/apiserver/service/product/ProductServiceTest.java
@@ -1,0 +1,159 @@
+package com.daangndaangn.apiserver.service.product;
+
+import com.daangndaangn.apiserver.entity.category.Category;
+import com.daangndaangn.apiserver.entity.product.ProductState;
+import com.daangndaangn.apiserver.entity.user.Location;
+import com.daangndaangn.apiserver.entity.user.User;
+import com.daangndaangn.apiserver.error.NotFoundException;
+import com.daangndaangn.apiserver.error.UnauthorizedException;
+import com.daangndaangn.apiserver.repository.CategoryRepository;
+import com.daangndaangn.apiserver.repository.UserRepository;
+import com.daangndaangn.apiserver.repository.product.ProductRepository;
+import com.daangndaangn.apiserver.service.category.CategoryService;
+import com.daangndaangn.apiserver.service.user.UserService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class ProductServiceTest {
+
+    private final Long USER_OAUTH_ID = 111L;
+    private final Long GENERATED_USER_ID = 1L;
+    private final Long CATEGORY_ID = 1L;
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private CategoryService categoryService;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeAll
+    public void init() {
+        userService.join(USER_OAUTH_ID, "프로필 주소");
+        userService.update(USER_OAUTH_ID, "Test", Location.from("Address"), "프로필 주소");
+        categoryRepository.save(Category.from("포켓몬"));
+        User seller = userService.findUserByOauthId(USER_OAUTH_ID);
+        productService.createProduct("피카츄 스티커 팔아요", "피카츄", CATEGORY_ID, 10000L, "싸게 팔아요~", null, seller.getId());
+        productService.createProduct("파이리 스티커 팔아요", "파이리", CATEGORY_ID, 20000L, "싸게 팔아요~", null, seller.getId());
+        productService.createProduct("꼬부기 스티커 팔아요", "꼬부기", CATEGORY_ID, 30000L, "싸게 팔아요~", null, seller.getId());
+    }
+
+
+    @Test
+    public void 물품을_조회하면_해당_물품을_반환한다() {
+        Long ProductId = 1L;
+
+        assertThat(productService.findProduct(ProductId).getId()).isEqualTo(ProductId);
+    }
+
+    @Test
+    public void 없는_물품을_조회하면_예외를_발생한다() {
+        Long InvalidProductId = 11111L;
+
+        assertThrows(NotFoundException.class, () -> productService.getProduct(InvalidProductId));
+    }
+
+    @Test
+    public void 물품을_등록한다() {
+        assertThat(productService.createProduct("리자몽 스티커 팔아요", "리자몽", CATEGORY_ID, 10000L, "싸게 팔아요~", null, GENERATED_USER_ID).getId()).isEqualTo(4L);
+    }
+
+    @Test
+    public void 물품을_등록할_때_userId가_null이면_예외를_발생한다() {
+        Long NullUserId = null;
+
+        assertThrows(IllegalArgumentException.class, () -> productService.createProduct("리자몽 스티커 팔아요", "리자몽", CATEGORY_ID, 10000L, "싸게 팔아요~", null, NullUserId));
+    }
+
+    @Test
+    public void 물품을_등록할_때_categoryId가_null이면_예외를_발생한다() {
+        Long NullCategoryId = null;
+
+        assertThrows(IllegalArgumentException.class, () -> productService.createProduct("리자몽 스티커 팔아요", "리자몽", NullCategoryId, 10000L, "싸게 팔아요~", null, 1L));
+    }
+
+    @Test
+    public void 물품을_등록할_때_존재하지_않는_회원이면_예외를_발생한다() {
+        Long InvalidUserId = 1111L;
+
+        assertThrows(NotFoundException.class, () -> productService.createProduct("리자몽 스티커 팔아요", "리자몽", CATEGORY_ID, 10000L, "싸게 팔아요~", null, InvalidUserId));
+    }
+
+    @Test
+    public void 물품을_등록할_때_존재하지_않는_카테고리면_예외를_발생한다() {
+        Long InvalidCategoryId = 1111L;
+
+        assertThrows(NotFoundException.class, () -> productService.createProduct("리자몽 스티커 팔아요", "리자몽", InvalidCategoryId, 10000L, "싸게 팔아요~", null, 1L));
+    }
+
+    @Test
+    public void 물품을_삭제한다() {
+        Long ProductId = 1L;
+
+        assertThat(productService.findProduct(ProductId).getId()).isEqualTo(ProductId);
+
+        productService.deleteProduct(ProductId, GENERATED_USER_ID);
+
+        assertThat(productService.findProduct(ProductId).getState()).isEqualTo(ProductState.DELETED);
+    }
+
+    @Test
+    public void 삭제할_때_판매자의_ID와_다르다면_예외를_발생한다() {
+        Long ProductId = 1L;
+        Long DiffUserId = 3L;
+        assertThat(productService.findProduct(ProductId).getId()).isEqualTo(ProductId);
+
+        assertThrows(UnauthorizedException.class, () -> productService.deleteProduct(ProductId, DiffUserId));
+    }
+
+    @Test
+    public void 물품_정보를_수정한다() {
+        Long ProductId = 1L;
+
+        assertThat(productService.findProduct(ProductId).getId()).isEqualTo(ProductId);
+
+        productService.updateProduct(ProductId, "수정", "수정", CATEGORY_ID, 1000L, "수정", GENERATED_USER_ID);
+
+        assertThat(productService.findProduct(ProductId).getTitle()).isEqualTo("수정");
+    }
+
+    @Test
+    public void 수정할_때_판매자의_ID와_다르다면_예외를_발생한다() {
+        Long ProductId = 1L;
+        Long DiffUserId = 3L;
+        assertThat(productService.findProduct(ProductId).getId()).isEqualTo(ProductId);
+
+        assertThrows(UnauthorizedException.class, () -> productService.updateProduct(ProductId, "수정", "수정", CATEGORY_ID, 1000L, "수정", DiffUserId));
+    }
+
+    @AfterAll
+    public void destroy() {
+        productRepository.deleteAll();
+        userRepository.deleteAll();
+        categoryRepository.deleteAll();
+    }
+}

--- a/chat-server/build.gradle
+++ b/chat-server/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation('org.springframework.boot:spring-boot-starter-data-mongodb')
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.webjars:sockjs-client:1.5.1'
+    implementation 'org.webjars:stomp-websocket:2.3.4'
 }

--- a/chat-server/src/main/java/com/daangndaangn/chatserver/configure/WebSocketConfig.java
+++ b/chat-server/src/main/java/com/daangndaangn/chatserver/configure/WebSocketConfig.java
@@ -1,0 +1,34 @@
+package com.daangndaangn.chatserver.configure;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker //메세지 브로커를 사용하겠다는 어노테이션
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        /*
+        소켓 연결을 할 때 사용되는 주소입니다.
+        http://localhost:9080/chat
+         */
+
+        registry.addEndpoint("/chat").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        /*
+        pub/sub 패턴에서 브로커 역할을 담당하는 주소입니다.
+        "/queue", "/topic" 이 두 경로가 prefix(api 경로 맨 앞)에 붙은 경우,
+        messageBroker가 잡아서 해당 채팅방을 구독하고 있는 클라이언트에게 메시지를 전달해줌
+
+        "/queue", "/topic"은 임의의 경로이며 변경할 수 있습니다.
+         */
+        config.enableSimpleBroker("/topic", "/queue");
+    }
+}

--- a/chat-server/src/main/java/com/daangndaangn/chatserver/controller/ChatController.java
+++ b/chat-server/src/main/java/com/daangndaangn/chatserver/controller/ChatController.java
@@ -1,0 +1,24 @@
+package com.daangndaangn.chatserver.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    //메세지 전송을 담당하는 객체
+    private final SimpMessageSendingOperations sendingOperations;
+
+    //메세지를 보낼 때 사용되는 함수
+    @MessageMapping("/send-message")
+//    @SendTo() : convertAndSend 메소드의 첫번째 인자인 경로를 설정할 수 있다는대, 활용법 공부 필요
+    public void sendMessage(String message){
+
+        //브로커가 /topic/방번호를 구독하고 있는 클라이언트에게 message를 전송합니다.
+        sendingOperations.convertAndSend("/topic/방번호", message);
+    }
+    
+}


### PR DESCRIPTION
작업 목록
- 회원 관련 물품 리스트 조회 메소드 합치기
   - 메인 조회 API와 필터 조회 API에서 사용되는 메소드를 하나로 사용할 수 있도록 했습니다.
- 물품 관련 테스트 코드 작성
   - 리스트 조회 함수는 미완성
- 채팅 서버 STOMP 설정 추가

논의 사항
1. 비회원 API의 경우 api/non-user/products로 하기로 했는데 product 컨트롤러의 prefix인 api/products를 수정해야 할지..
2. 비회원 전용 물품 리스트 조회 API의 서비스 계층 함수도 회원 전용 물품 리스트 조회 API를 재사용하려 했으나 따로 해야할 거 같은데 어떻게 생각하시는지
3. 필터 조건의 minPrice와 maxPrice가 있는데 minPrice가 maxPrice보다 크게 입력되면 valid 체크로 예외를 발생하려고 하는데 checkArgument 메소드 내에 어떤 조건을 써야할지..